### PR TITLE
Potential fix for code scanning alert no. 4: Flask app is run in debug mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -394,4 +394,6 @@ def api_get_email(email_id):
         }), 500
 
 if __name__ == '__main__':
-    app.run(debug=True)
+    # Enable debug mode only when explicitly requested via environment variable
+    debug_mode = os.environ.get('FLASK_DEBUG', '').lower() in ('1', 'true', 'yes')
+    app.run(debug=debug_mode)


### PR DESCRIPTION
Potential fix for [https://github.com/valerio-vaccaro/ghostinbox.it/security/code-scanning/4](https://github.com/valerio-vaccaro/ghostinbox.it/security/code-scanning/4)

To fix this, remove the unconditional `debug=True` flag and make debug behavior depend on environment/configuration, defaulting to safe (debug disabled) for any non-explicit development environment. This preserves existing functionality for development while preventing accidental debug mode in production.

The best minimal change is to read an environment variable, e.g. `FLASK_DEBUG`, interpret it as a boolean, and pass that to `app.run`. Since `os` is already imported at the top of `app.py`, no new imports are needed. Concretely, in `app.py` around line 396–397, replace `app.run(debug=True)` with code that computes `debug_mode` from the environment and calls `app.run(debug=debug_mode)`. This keeps the same behavior for developers who set `FLASK_DEBUG=1` (or similar), and disables debug by default otherwise. No other parts of the file need to change.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
