### PR TITLE
Potential fix for code scanning alert no. 1: Clear-text logging of sensitive information

### DIFF
--- a/app.py
+++ b/app.py
@@ -24,7 +24,7 @@ ONION_DOMAIN = os.getenv('ONION_DOMAIN')
 # Example usage (e.g., connecting to an IMAP server)
 # Replace this with your actual code
 print(f"Email: {EMAIL_ADDRESS}")
-print(f"Password: {PASSWORD}")
+print("Password configured: " + ("YES" if PASSWORD else "NO"))
 
 # Libero.it IMAP settings
 IMAP_SERVER = 'imapmail.libero.it'


### PR DESCRIPTION
Potential fix for [https://github.com/valerio-vaccaro/ghostinbox.it/security/code-scanning/1](https://github.com/valerio-vaccaro/ghostinbox.it/security/code-scanning/1)

In general, to fix clear-text logging of sensitive data, remove logs that contain secrets (passwords, tokens, keys, etc.), or replace them with redacted/masked forms that do not expose the full value. Logging the *presence* of a configuration value (e.g., “password configured: yes/no”) is usually sufficient for diagnostics.

For this specific case in `app.py`, we should stop printing the actual password at lines 26–27. The best minimal-impact fix is:
- Remove or change the two `print` statements so they do not log sensitive data.
- If you still want a startup diagnostic, you can log only non-sensitive values (e.g., the email address) and replace the password output with a generic message like `"Password: [REDACTED]"` or, better, a boolean such as `"Password set: True/False"`.

This keeps existing behavior of reading configuration from environment variables and does not alter any application logic, while eliminating the risky clear-text password logging.

Concretely:
- In `app.py`, replace:
  - `print(f"Email: {EMAIL_ADDRESS}")`
  - `print(f"Password: {PASSWORD}")`
- With something like:
  - `print(f"Email: {EMAIL_ADDRESS}")`
  - `print("Password configured: " + ("YES" if PASSWORD else "NO"))`
  
No new methods are needed. No existing imports need to be changed or added.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
