### PR TITLE
Potential fix for code scanning alert no. 7: Information exposure through an exception

### DIFF
--- a/app.py
+++ b/app.py
@@ -7,12 +7,16 @@ import os
 import re
 import base64
 from dotenv import load_dotenv
+import logging
 
 # Load environment variables from .env file
 load_dotenv()
 
 app = Flask(__name__)
 app.secret_key = os.environ.get('FLASK_SECRET_KEY', 'fallback-secret-key-for-development')
+
+# Basic logging configuration; adjust level/handlers as needed.
+logging.basicConfig(level=logging.INFO)
 
 # Retrieve email and password from environment variables
 EMAIL_ADDRESS = os.getenv('BASE_EMAIL')
@@ -343,9 +347,11 @@ def api_list_emails():
         })
     
     except Exception as e:
+        # Log the full exception details on the server, but do not expose them to the client.
+        logging.exception("Error while listing emails")
         return jsonify({
             'success': False,
-            'error': str(e)
+            'error': 'An internal error has occurred while listing emails.'
         }), 500
 
 @app.route('/api/emails/<email_id>')
@@ -386,11 +392,13 @@ def api_get_email(email_id):
             'success': True,
             'email': email_data
         })
+        # Log the full exception details on the server, but return a generic message to the client.
+        logging.exception("Error while retrieving email")
     
     except Exception as e:
         return jsonify({
             'success': False,
-            'error': str(e)
+            'error': 'An internal error has occurred while retrieving the email.'
         }), 500
 
 if __name__ == '__main__':


### PR DESCRIPTION
Potential fix for [https://github.com/valerio-vaccaro/ghostinbox.it/security/code-scanning/7](https://github.com/valerio-vaccaro/ghostinbox.it/security/code-scanning/7)

To fix the problem, the API should stop returning the raw exception message (`str(e)`) to the client and instead return a generic error message while logging the detailed error on the server for debugging. This preserves functionality (clients still receive an error indication and appropriate HTTP status) but avoids leaking internal details.

The best way to do this with minimal functional change is:
- Import Python’s standard `logging` module at the top of `app.py` and configure a logger (even a simple default setup is fine if none exists).
- In both exception handlers (`/api/search` and `/api/emails/<email_id>`), replace `error: str(e)` with a generic error string (for example `"An internal error has occurred"` or a route-specific message).
- In those `except` blocks, log the exception using `logging.exception(...)` so that the full stack trace is stored server-side, but not exposed to users.

Concretely:
- In `app.py` near the other imports (line 2–9 area), add `import logging`.
- Optionally add a basic logging configuration (for example `logging.basicConfig(level=logging.INFO)` or similar) just after creating the Flask app or after imports, if none exists elsewhere in the snippet.
- In the `/api/search` handler’s `except` block (lines 345–349), add a logging call like `logging.exception("Error while listing emails")` and change the JSON error field to a fixed string.
- In the `/api/emails/<email_id>` handler’s `except` block (lines 390–394), add `logging.exception("Error while retrieving email")` and change the JSON error field to a fixed string.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
